### PR TITLE
Github issue response

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,7 +16,7 @@ from PIL import Image
 
 from .schemas import ClassifyResponse, ErrorBody, LabelScore
 from .vision_provider import get_provider
-from .rules import decide_bin_from_profile, decide_bin_from_labels, apply_clarification
+from .rules import decide_bin_from_profile, apply_clarification
 
 
 MAX_BYTES = 8 * 1024 * 1024  # 8MB


### PR DESCRIPTION
Remove unused `decide_bin_from_labels` import from `backend/app/main.py` as `decide_bin_from_profile` is now used instead.

---
<a href="https://cursor.com/background-agent?bcId=bc-be95c911-f6b4-4d74-83b7-f872396992c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-be95c911-f6b4-4d74-83b7-f872396992c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minor cleanup in backend API.
> 
> - Remove unused `decide_bin_from_labels` import from `backend/app/main.py`; `decide_bin_from_profile` and `apply_clarification` remain
> - No functional or API changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0432d45eb6be87b7bcd0235655d37c8a707cc7ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->